### PR TITLE
Fix docker build & adjust naming with conventions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:10
 LABEL maintainer="johnh@benetech.org"
 VOLUME /tmp
-ADD *.jar app.jar
+ADD target/mathshare*.jar app.jar
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
 EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     server:
-        image: benetech/mathshare.server
+        image: benetech/mathshare-server
         env_file: .env
         ports:
             - 8080:8080

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.benetech</groupId>
-    <artifactId>mathshare.server</artifactId>
+    <artifactId>mathshare-server</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
The build was broken so I fixed. I also changed the naming
from mathshare.server to mathshare-server, since
dashes are more common in image and artifact names than dots.