### PR TITLE
Move maven artifact building to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,23 @@
-FROM openjdk:10
+FROM adoptopenjdk/maven-openjdk10 as maven
 LABEL maintainer="johnh@benetech.org"
-VOLUME /tmp
-ADD target/mathshare*.jar app.jar
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
-EXPOSE 8080
+
+COPY ./pom.xml ./pom.xml
+
+# build all dependencies
+RUN mvn dependency:go-offline -B
+
+# copy your other files
+COPY ./src ./src
+COPY ./checkstyle ./checkstyle
+
+# build for release
+RUN mvn package
+
+# our final base image
+FROM openjdk:10-jre-slim
+
+# set deployment directory
+WORKDIR /mathshare
+
+# copy over the built artifact from the maven image
+COPY --from=maven target/mathshare-*.jar ./app.jar

--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ This is a repository for MathShare backend server. MathShare is a step by step e
 
 ## Building the app
 
+### Dockerized environment
+
+There is a possibility to run MathShareBackend application in an environment based on Docker. This environment consists of two images:
+ - server - MathShareBackend application
+ - postgresql - PostgreSQL database image
+ 
+Using this approach allows to run the application in an environment independent of a host. It simplifies a potential configuration and provides a possibilty to clean restart the application.
+
+#### Windows
+On Windows, there are two options for runninng Docker:
+* based on Hyper-V (requires Windows 10 Pro or higher)
+* based on Virtual Machine - installed by Docker Toolbox
+
+Both requires BIOS supported virtualization. This guide has been prepared using Docker based on Virtual Machine version. It is important to notice that Docker for Windows based on Virtual Machine uses a **different IP** (eg. 192.168.99.100) so the MathShareBackend server application may be different.
+
+You can get the IP by opening Docker Quickstart Terminal - the URL should be displayed as a welcome message.
+
+### Without docker-compose
+
 First, we need to run a PostgreSQL database, the most convenient way to run it is to use Docker.
 The following command will create a Docker container with all properties configured (database and user).
 
@@ -40,34 +59,11 @@ After running the command ```bash  ./mvnw clean install ``` (for Unix systems) o
 You could also build and run the app from your favourite IDE, we recommend IntelliJ IDEA.
 It is recommended to use pgadmin4 to connect to PostgreSQL database.
 
-## Dockerized environment
+### With docker-compose
 
-There is a possibility to run MathShareBackend application in an environment based on Docker. This environment consists of two images:
- - server - MathShareBackend application
- - postgresql - PostgreSQL database image
- 
-Using this approach allows to run the application in an environment independent of a host. It simplifies a potential configuration and provides a possibilty to clean restart the application.
+#### Running the environment
 
-### Windows
-On Windows, there are two options for runninng Docker:
-* based on Hyper-V (requires Windows 10 Pro or higher)
-* based on Virtual Machine - installed by Docker Toolbox
-
-Both requires BIOS supported virtualization. This guide has been prepared using Docker based on Virtual Machine version. It is important to notice that Docker for Windows based on Virtual Machine uses a **different IP** (eg. 192.168.99.100) so the MathShareBackend server application may be different.
-
-You can get the IP by opening Docker Quickstart Terminal - the URL should be displayed as a welcome message. 
-
-### Building a docker image
-
-To build an image run the command below in the root project directory:
-
-```bash
-mvn clean package docker:build
-```
-
-### Running the environment
-
-If the process completes with success, a new docker image should be created. Now it is possible to run the whole docker environment (the command should be executed in the root project directory - a docker-compose.yml file should be visible there).
+This command should be executed in the root project directory (a docker-compose.yml file should be visible there).
 
 ```bash
 docker-compose up
@@ -84,6 +80,15 @@ Optionally, you can also remove the non-volatile database storage by removing th
 ```bash
 docker-compose down -v && docker-compose up
 ```
+
+#### Copying artifact from container to the host
+
+To get the built maven artifact from docker container run this:
+
+```bash
+docker cp "$(docker-compose ps -q server)":/mathshare/app.jar /location/of/output
+```
+
 
 ### Docker variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,13 @@ version: '3'
 services:
     server:
         image: benetech/mathshare-server
+        build: .
         env_file: .env
         ports:
             - 8080:8080
         depends_on:
             - postgresql
+        entrypoint: java -Djava.security.egd=file:/dev/./urandom -jar /mathshare/app.jar
     postgresql:
         image: postgres:9.5.12
         env_file: .env


### PR DESCRIPTION
While trying to run backend I was facing some issues because of my local environment

To fix it I have moved artifcat building to docker so that there are no build issues due to the environment

Also, while moving the artifact build process to docker, I have made sure that build doesn't take a long time after the first build and the plugins get cached. I have changed the base image to a JRE to reduce the image size from 1GB to 300MB. I have also updated the README to reflect the updated build process using only docker-compose